### PR TITLE
Added persistent provisioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ First release
 
 ```bash
 curl -o /srv/unifi/data/sites/default/config.gateway.json https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/config.gateway.json
+chown unifi.unifi /srv/unifi/data/sites/default/config.gateway.json
 ```
 
 3. You should then run a Force Provision on the Security Gateway from the unifi controllers web gui.

--- a/README.md
+++ b/README.md
@@ -1,33 +1,42 @@
-<h1>Ubiquiti USG DNS Based adblocker</h1>
+#Ubiquiti USG DNS Based adblocker
+##What does this do
+This uses your [Ubiquiti Security Gateway](https://www.ubnt.com/unifi-routing/usg/) device as a DNS blackhole, much like [pi-hole](https://pi-hole.net/) does. It will download daily various known and trusted blacklists for advertisement, spyware, malware and tracking networks and makes it so that their DNS address resolves to 0.0.0.0 instead of the actual IP address. The result is that no data is downloaded from, or uploaded to, those networks.
 
-<b>NOTE: after a firmware upgrade, the script needs to be executed again manually to re-create the crontab job and refill the dnsmasq list. <br><br>
-So after a firmware upgrade, log in using SSH, sudo to root and run /config/user-data/update-adblock-dnsmasq.sh</b>
-<br>
-<h1>What does this do</h1>
-This uses your <a href="https://www.ubnt.com/unifi-routing/usg/">Ubiquiti Security Gateway</a> device as a DNS blackhole, much like <a href="https://pi-hole.net/">pi-hole</a> does. It automatically, daily, downloads various known and trusted blacklists for advertisement, spyware, malware and tracking networks and makes it so that their DNS address resolves to 0.0.0.0 instead of the actual IP address. The result is that no data is downloaded from, or uploaded to, those networks.<br>
+##versions
+20190320 (jsamuel1 fork)
+-added persistance on firmware upgrade via config.gateway.json
+20171203 (Ar0xA baseline)
+-added first youtube adblocking
+20171121
+First release
+-added pi-hole domains as suggsted by @recrudesce
+-added https://github.com/notracking/hosts-blocklists
 
-<h1>versions</h1>
-20171203<br>
--added first youtube adblocking <br>
-20171121<br>
-First release<br>
--added pi-hole domains as suggsted by @recrudesce <br>
--added https://github.com/notracking/hosts-blocklists<br>
-<br>
-<h1>How to install</h1>
+##How to install
 
-SSH into your USG:<br>
-<br>
-sudo su -<br>
-curl -o /config/user-data/update-adblock-dnsmasq.sh https://raw.githubusercontent.com/Ar0xA/USG-DNS-ADBLOCK/master/update-adblock-dnsmasq.sh<br>
-chmod +x /config/user-data/update-adblock-dnsmasq.sh<br>
-/config/user-data/update-adblock-dnsmasq.sh<br>
+1. SSH into your CloudKey or Controler.
 
+2. If you don't have an existing config.gateway.json, copy the file here into the <unifi_base>/data/sites/site_ID directory.
+
+* On a CloudKey, with the default site, the command to run will be:
+
+```bash
+curl -o /srv/unifi/data/sites/default/config.gateway.json https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/config.gateway.json
+```
+
+3. You should then run a Force Provision on the Security Gateway from the unifi controllers web gui.
+
+4. Once your device has re-started, it will wait 2 minutes before installing the adblocking dnsmasq config.
 
 Check if all went fine by nslookup on a box that uses your USG as DNS (default from DHCP)<br>
-nslookup aa.i-stream.pl (should return address: 0.0.0.0)<br>
-<br>
-crontab -l should show you now a line to automatically update once a day<br>
-<br>
+
+```bash
+nslookup aa.i-stream.pl
+```
+
+should return address: 0.0.0.0
+
+## Appendix
 Originally taken from https://community.ubnt.com/t5/UniFi-Routing-Switching/Use-USG-to-block-sites-apps-like-ER/td-p/1497045
 
+For information about config.gateway.json, see https://help.ubnt.com/hc/en-us/articles/215458888-UniFi-USG-Advanced-Configuration for details.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 This uses your [Ubiquiti Security Gateway](https://www.ubnt.com/unifi-routing/usg/) device as a DNS blackhole, much like [pi-hole](https://pi-hole.net/) does. It will download daily various known and trusted blacklists for advertisement, spyware, malware and tracking networks and makes it so that their DNS address resolves to 0.0.0.0 instead of the actual IP address. The result is that no data is downloaded from, or uploaded to, those networks.
 
 ## versions
-20190320 (jsamuel1 fork)
+20190320 (@jsamuel1)
 * added persistance on firmware upgrade via config.gateway.json
 
-20171203 (Ar0xA baseline)
+20171203 (Ar0xA)
 * added first youtube adblocking
 
 20171121
@@ -23,7 +23,7 @@ First release
 * On a CloudKey, with the default site, the command to run will be:
 
 ```bash
-curl -o /srv/unifi/data/sites/default/config.gateway.json https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/config.gateway.json
+curl -o /srv/unifi/data/sites/default/config.gateway.json https://raw.githubusercontent.com/ar0xa/USG-DNS-ADBLOCK/master/config.gateway.json
 chown unifi.unifi /srv/unifi/data/sites/default/config.gateway.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
-#Ubiquiti USG DNS Based adblocker
-##What does this do
+# Ubiquiti USG DNS Based adblocker
+## What does this do
 This uses your [Ubiquiti Security Gateway](https://www.ubnt.com/unifi-routing/usg/) device as a DNS blackhole, much like [pi-hole](https://pi-hole.net/) does. It will download daily various known and trusted blacklists for advertisement, spyware, malware and tracking networks and makes it so that their DNS address resolves to 0.0.0.0 instead of the actual IP address. The result is that no data is downloaded from, or uploaded to, those networks.
 
-##versions
+## versions
 20190320 (jsamuel1 fork)
--added persistance on firmware upgrade via config.gateway.json
+* added persistance on firmware upgrade via config.gateway.json
+
 20171203 (Ar0xA baseline)
--added first youtube adblocking
+* added first youtube adblocking
+
 20171121
 First release
--added pi-hole domains as suggsted by @recrudesce
--added https://github.com/notracking/hosts-blocklists
+* added pi-hole domains as suggsted by @recrudesce
+* added https://github.com/notracking/hosts-blocklists
 
-##How to install
+## How to install
 
 1. SSH into your CloudKey or Controler.
 

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -1,0 +1,15 @@
+{
+	"system": {
+		"task-scheduler": {
+			"task": {
+				"runonprovision": {
+					"executable": {
+						"path": "/usr/bin/curl",
+						"arguments": "--silent https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/runonprovision.sh > /config/scripts/runonprovision.sh; /bin/chmod +x /config/scripts/runonprovision.sh; /config/scripts/runonprovision.sh"
+					},
+					"interval": "2m"
+				}
+			}
+		}
+	}
+}

--- a/config.gateway.json
+++ b/config.gateway.json
@@ -5,7 +5,7 @@
 				"runonprovision": {
 					"executable": {
 						"path": "/usr/bin/curl",
-						"arguments": "--silent https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/runonprovision.sh > /config/scripts/runonprovision.sh; /bin/chmod +x /config/scripts/runonprovision.sh; /config/scripts/runonprovision.sh"
+						"arguments": "--silent https://raw.githubusercontent.com/ar0xa/USG-DNS-ADBLOCK/master/runonprovision.sh > /config/scripts/runonprovision.sh; /bin/chmod +x /config/scripts/runonprovision.sh; /config/scripts/runonprovision.sh"
 					},
 					"interval": "2m"
 				}

--- a/runonprovision.sh
+++ b/runonprovision.sh
@@ -1,0 +1,25 @@
+#!/bin/vbash
+
+# This script is based on the ubnt community message at:
+# https://community.ubnt.com/t5/UniFi-Routing-Switching/Deploying-USG-scripts-through-controller/td-p/2140097
+
+#the following lines remove the runonprovision scheduled task
+#do not modify below this line until 'end no edit'
+
+readonly logFile="/var/log/runonprovision.log"
+
+source /opt/vyatta/etc/functions/script-template
+
+configure > ${logFile}
+delete system task-scheduler task runonprovision  >> ${logFile}
+commit >> ${logFile}
+save >> ${logFile}
+#exit
+
+#end no edit
+
+/usr/bin/curl --silent -o /config/user-data/update-adblock-dnsmasq.sh https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/update-adblock-dnsmasq.sh
+sudo /bin/chmod a+x /config/user-data/update-adblock-dnsmasq.sh
+sudo /config/user-data/update-adblock-dnsmasq.sh
+
+crontab -l > /config/scripts/testworked.log

--- a/runonprovision.sh
+++ b/runonprovision.sh
@@ -18,7 +18,7 @@ save >> ${logFile}
 
 #end no edit
 
-/usr/bin/curl --silent -o /config/user-data/update-adblock-dnsmasq.sh https://raw.githubusercontent.com/jsamuel1/USG-DNS-ADBLOCK/master/update-adblock-dnsmasq.sh
+/usr/bin/curl --silent -o /config/user-data/update-adblock-dnsmasq.sh https://raw.githubusercontent.com/ar0xa/USG-DNS-ADBLOCK/master/update-adblock-dnsmasq.sh
 sudo /bin/chmod a+x /config/user-data/update-adblock-dnsmasq.sh
 sudo /config/user-data/update-adblock-dnsmasq.sh
 


### PR DESCRIPTION
Added in persistent provisioning - curl to the controller/cloud key, rather than directly to the USG.   This should now re-apply automatically on USG firmware upgrades.